### PR TITLE
Use `dmidecode` crate to avoid hostbin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,12 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -256,6 +262,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dmidecode"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82706a4bb0cc98a506c471ea366783bc8378f049fafb832c3b1cf2183757d96"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "edera-check"
 version = "0.2.13"
 dependencies = [
@@ -265,6 +280,7 @@ dependencies = [
  "chrono",
  "clap",
  "console",
+ "dmidecode",
  "env_logger",
  "flate2",
  "futures",
@@ -520,7 +536,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "redox_syscall 0.7.1",
 ]
@@ -579,7 +595,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -609,7 +625,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -693,7 +709,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "chrono",
  "flate2",
  "procfs-core",
@@ -706,7 +722,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "chrono",
  "hex",
 ]
@@ -726,7 +742,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -735,7 +751,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -773,7 +789,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ async-trait = "0.1"
 clap = { version = "4.6", features = ["derive"] }
 console = "0.16"
 bytesize = "2.3"
+dmidecode = "0.9"

--- a/src/recorders/postinstall/system.rs
+++ b/src/recorders/postinstall/system.rs
@@ -162,16 +162,15 @@ impl SystemRecorder {
 
         self.host_executor
             .spawn_in_host_ns(async {
-                let ep_bytes =
-                    match std::fs::read("/sys/firmware/dmi/tables/smbios_entry_point") {
-                        Ok(b) => b,
-                        Err(e) => {
-                            return CheckResult::new(
-                                NAME,
-                                Skipped(format!("could not read smbios_entry_point: {e}")),
-                            )
-                        }
-                    };
+                let ep_bytes = match std::fs::read("/sys/firmware/dmi/tables/smbios_entry_point") {
+                    Ok(b) => b,
+                    Err(e) => {
+                        return CheckResult::new(
+                            NAME,
+                            Skipped(format!("could not read smbios_entry_point: {e}")),
+                        );
+                    }
+                };
 
                 let entry_point = match dmidecode::EntryPoint::search(&ep_bytes) {
                     Ok(ep) => ep,
@@ -179,7 +178,7 @@ impl SystemRecorder {
                         return CheckResult::new(
                             NAME,
                             Skipped(format!("could not parse DMI entry point: {e:?}")),
-                        )
+                        );
                     }
                 };
 
@@ -189,7 +188,7 @@ impl SystemRecorder {
                         return CheckResult::new(
                             NAME,
                             Skipped(format!("could not read DMI table: {e}")),
-                        )
+                        );
                     }
                 };
 

--- a/src/recorders/postinstall/system.rs
+++ b/src/recorders/postinstall/system.rs
@@ -158,7 +158,53 @@ impl SystemRecorder {
     /// dmidecode
     /// ```
     pub async fn record_dmidecode(&self) -> CheckResult {
-        self.run_tool("dmidecode").await
+        const NAME: &str = "Captured dmidecode";
+
+        self.host_executor
+            .spawn_in_host_ns(async {
+                let ep_bytes =
+                    match std::fs::read("/sys/firmware/dmi/tables/smbios_entry_point") {
+                        Ok(b) => b,
+                        Err(e) => {
+                            return CheckResult::new(
+                                NAME,
+                                Skipped(format!("could not read smbios_entry_point: {e}")),
+                            )
+                        }
+                    };
+
+                let entry_point = match dmidecode::EntryPoint::search(&ep_bytes) {
+                    Ok(ep) => ep,
+                    Err(e) => {
+                        return CheckResult::new(
+                            NAME,
+                            Skipped(format!("could not parse DMI entry point: {e:?}")),
+                        )
+                    }
+                };
+
+                let table_bytes = match std::fs::read("/sys/firmware/dmi/tables/DMI") {
+                    Ok(b) => b,
+                    Err(e) => {
+                        return CheckResult::new(
+                            NAME,
+                            Skipped(format!("could not read DMI table: {e}")),
+                        )
+                    }
+                };
+
+                let mut output = String::new();
+                for structure in entry_point.structures(&table_bytes) {
+                    match structure {
+                        Ok(s) => output.push_str(&format!("{s:#?}\n")),
+                        Err(e) => output.push_str(&format!("Error: {e:?}\n")),
+                    }
+                }
+
+                CheckResult::new_with_output(NAME, Passed, Some(output.trim().to_string()))
+            })
+            .await
+            .unwrap_or_else(|e| CheckResult::new(NAME, Skipped(e.to_string())))
     }
 
     /// Records the Xen hypervisor console log via the protect-ctl tool.

--- a/src/recorders/preinstall/system.rs
+++ b/src/recorders/preinstall/system.rs
@@ -153,16 +153,15 @@ impl SystemRecorder {
 
         self.host_executor
             .spawn_in_host_ns(async {
-                let ep_bytes =
-                    match std::fs::read("/sys/firmware/dmi/tables/smbios_entry_point") {
-                        Ok(b) => b,
-                        Err(e) => {
-                            return CheckResult::new(
-                                NAME,
-                                Skipped(format!("could not read smbios_entry_point: {e}")),
-                            )
-                        }
-                    };
+                let ep_bytes = match std::fs::read("/sys/firmware/dmi/tables/smbios_entry_point") {
+                    Ok(b) => b,
+                    Err(e) => {
+                        return CheckResult::new(
+                            NAME,
+                            Skipped(format!("could not read smbios_entry_point: {e}")),
+                        );
+                    }
+                };
 
                 let entry_point = match dmidecode::EntryPoint::search(&ep_bytes) {
                     Ok(ep) => ep,
@@ -170,7 +169,7 @@ impl SystemRecorder {
                         return CheckResult::new(
                             NAME,
                             Skipped(format!("could not parse DMI entry point: {e:?}")),
-                        )
+                        );
                     }
                 };
 
@@ -180,7 +179,7 @@ impl SystemRecorder {
                         return CheckResult::new(
                             NAME,
                             Skipped(format!("could not read DMI table: {e}")),
-                        )
+                        );
                     }
                 };
 

--- a/src/recorders/preinstall/system.rs
+++ b/src/recorders/preinstall/system.rs
@@ -149,7 +149,53 @@ impl SystemRecorder {
     /// dmidecode
     /// ```
     pub async fn record_dmidecode(&self) -> CheckResult {
-        self.run_tool("dmidecode").await
+        const NAME: &str = "Captured dmidecode";
+
+        self.host_executor
+            .spawn_in_host_ns(async {
+                let ep_bytes =
+                    match std::fs::read("/sys/firmware/dmi/tables/smbios_entry_point") {
+                        Ok(b) => b,
+                        Err(e) => {
+                            return CheckResult::new(
+                                NAME,
+                                Skipped(format!("could not read smbios_entry_point: {e}")),
+                            )
+                        }
+                    };
+
+                let entry_point = match dmidecode::EntryPoint::search(&ep_bytes) {
+                    Ok(ep) => ep,
+                    Err(e) => {
+                        return CheckResult::new(
+                            NAME,
+                            Skipped(format!("could not parse DMI entry point: {e:?}")),
+                        )
+                    }
+                };
+
+                let table_bytes = match std::fs::read("/sys/firmware/dmi/tables/DMI") {
+                    Ok(b) => b,
+                    Err(e) => {
+                        return CheckResult::new(
+                            NAME,
+                            Skipped(format!("could not read DMI table: {e}")),
+                        )
+                    }
+                };
+
+                let mut output = String::new();
+                for structure in entry_point.structures(&table_bytes) {
+                    match structure {
+                        Ok(s) => output.push_str(&format!("{s:#?}\n")),
+                        Err(e) => output.push_str(&format!("Error: {e:?}\n")),
+                    }
+                }
+
+                CheckResult::new_with_output(NAME, Passed, Some(output.trim().to_string()))
+            })
+            .await
+            .unwrap_or_else(|e| CheckResult::new(NAME, Skipped(e.to_string())))
     }
 
     /// Records CPU hardware details and feature flags.


### PR DESCRIPTION
https://docs.rs/dmidecode/latest/dmidecode/

This captures all of the bytes, but does not fully decode as many into human-readable format as the binary does.

But it has the added benefit of working exactly the same way inside and outside of a container, and not requiring a host (or container) bin, or a custom impl, so on the whole I like it better as an option.

I looked at possibly just slurping raw bytes from `/sys/firmware/dmi/tables/` in the the host namespace context, and then replaying the raw bytes from that against an OCI-local `dmidecode` binary - but `dmidecode` has some quirks that make that tricky, and that doesn't solve for running the naked `edera-check` binary outside of an OCI image - this does.

Fixes part-of: https://github.com/edera-dev/edera-check/issues/86