### PR TITLE
`preinstall`, like `postinstall` should also check loadable (versus just loaded or builtin)

### DIFF
--- a/src/checkers/preinstall/iommu.rs
+++ b/src/checkers/preinstall/iommu.rs
@@ -72,7 +72,7 @@ impl IOMMUChecks {
             .await
         {
             Ok(true) => CheckResult::new(&name, Passed),
-            Ok(false) => CheckResult::new(&name, Failed("no IOMMU detected".to_string())),
+            Ok(false) => CheckResult::new(&name, Failed("no hardware IOMMU detected".to_string())),
             Err(e) => {
                 debug!("Error: {}", e);
                 CheckResult::new(&name, Errored(e.to_string()))

--- a/src/checkers/preinstall/kernel.rs
+++ b/src/checkers/preinstall/kernel.rs
@@ -46,12 +46,18 @@ impl KernelChecks {
         }
     }
 
-    /// Checks that `nf_tables` and `msr` are either built into or loaded by the running kernel.
+    /// Checks that `nf_tables` and `msr` are built into, currently loaded by, or loadable
+    /// (present in `modules.dep`) on the running kernel.
     ///
     /// Manual equivalent:
     /// ```sh
-    /// grep -E 'nf_tables|msr' /lib/modules/$(uname -r)/modules.builtin
-    /// grep -E '^nf_tables |^msr ' /proc/modules
+    /// KV=$(uname -r)
+    /// for mod in nf_tables msr; do
+    ///   grep -q "$mod" /lib/modules/$KV/modules.builtin \
+    ///     || grep -q "^${mod} " /proc/modules \
+    ///     || grep -q "$mod" /lib/modules/$KV/modules.dep \
+    ///     && echo "$mod: OK" || echo "$mod: MISSING"
+    /// done
     /// ```
     async fn has_modules(&self) -> CheckResult {
         let name = String::from("Host Has Necessary Modules");
@@ -69,6 +75,14 @@ impl KernelChecks {
 
         // Search loaded modules
         let remaining = match khelper::find_loaded(&self.host_executor, &remaining).await {
+            Ok(r) => r,
+            Err(e) => {
+                return CheckResult::new(&name, Errored(format!("getting kernel modules {e}")));
+            }
+        };
+
+        // Search loadable modules (present in modules.dep but not yet loaded)
+        let remaining = match khelper::find_loadable(&self.host_executor, &remaining).await {
             Ok(r) => r,
             Err(e) => {
                 return CheckResult::new(&name, Errored(format!("getting kernel modules {e}")));

--- a/src/checkers/preinstall/pvh.rs
+++ b/src/checkers/preinstall/pvh.rs
@@ -98,10 +98,7 @@ impl PVHChecks {
             }
             Ok(VirtStatus::Disabled) => {
                 debug!("Virtualization disabled");
-                CheckResult::new(
-                    &name,
-                    Failed(String::from("Virtualization Disabled")),
-                )
+                CheckResult::new(&name, Failed(String::from("Virtualization Disabled")))
             }
             Err(e) => {
                 error!("Error: {}", e);

--- a/src/checkers/preinstall/pvh.rs
+++ b/src/checkers/preinstall/pvh.rs
@@ -98,7 +98,10 @@ impl PVHChecks {
             }
             Ok(VirtStatus::Disabled) => {
                 debug!("Hardware Virtualization disabled");
-                CheckResult::new(&name, Failed(String::from("Hardware Virtualization Disabled")))
+                CheckResult::new(
+                    &name,
+                    Failed(String::from("Hardware Virtualization Disabled")),
+                )
             }
             Err(e) => {
                 error!("Error: {}", e);

--- a/src/checkers/preinstall/pvh.rs
+++ b/src/checkers/preinstall/pvh.rs
@@ -100,7 +100,7 @@ impl PVHChecks {
                 debug!("Virtualization disabled");
                 CheckResult::new(
                     &name,
-                    Failed(String::from("PVH Not Supported, Virtualization Disabled")),
+                    Failed(String::from("Virtualization Disabled")),
                 )
             }
             Err(e) => {
@@ -304,7 +304,7 @@ impl CheckGroup for PVHChecks {
     }
 
     fn category(&self) -> CheckGroupCategory {
-        CheckGroupCategory::Optional("PVH feature not available on this system".into())
+        CheckGroupCategory::Optional("PVH feature may not be available on this system".into())
     }
 }
 

--- a/src/checkers/preinstall/pvh.rs
+++ b/src/checkers/preinstall/pvh.rs
@@ -93,12 +93,12 @@ impl PVHChecks {
 
         match self.discover_cpu_virtualization().await {
             Ok(VirtStatus::Enabled) | Ok(VirtStatus::CanBeEnabled) => {
-                debug!("Virtualization is enabled or can be enabled");
+                debug!("Hardware Virtualization is enabled or can be enabled");
                 CheckResult::new(&name, Passed)
             }
             Ok(VirtStatus::Disabled) => {
-                debug!("Virtualization disabled");
-                CheckResult::new(&name, Failed(String::from("Virtualization Disabled")))
+                debug!("Hardware Virtualization disabled");
+                CheckResult::new(&name, Failed(String::from("Hardware Virtualization Disabled")))
             }
             Err(e) => {
                 error!("Error: {}", e);


### PR DESCRIPTION
Fixes spurious `msr` failure in https://github.com/edera-dev/edera-check/issues/86, and updates PVH/iommu failure messages to be more specific that not being able to detect during preinstall means PVH *may* not be supported.

We have logic to check loaded, loadable, and builtins, but `preinstall` was incorrectly missing the load`able` check, causing the spurious failure.