### PR TITLE
Add `collect` subcommand that only runs postinstall debug collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ Run this on a system that has been booted into an Edera installation to validate
 
 ---
 
+### Generate system report
+
+```bash
+sudo edera-check collect
+```
+
+Run this on a system that has been booted into an Edera installation to collect a system report, including logs and other useful troubleshooting information.
+
+---
+
 ## Example Output
 
 ```text

--- a/src/collect_cmd.rs
+++ b/src/collect_cmd.rs
@@ -1,0 +1,41 @@
+use crate::{create_base_path, create_gzip_from, write_group_report};
+use edera_check::recorders::postinstall::system::SystemRecorder as postrecorder;
+
+use anyhow::{Result, anyhow};
+use console::style;
+use edera_check::helpers::{CheckGroup, host_executor::HostNamespaceExecutor};
+use std::{env, path::PathBuf};
+
+pub async fn do_collect(report_dir: Option<String>) -> Result<()> {
+    let host_executor = HostNamespaceExecutor::new();
+
+    let groups: Vec<Box<dyn CheckGroup>> = vec![Box::new(postrecorder::new(host_executor.clone()))];
+
+    let hostname = host_executor
+        .spawn_in_host_ns(async { std::fs::read_to_string("/proc/sys/kernel/hostname").unwrap() })
+        .await?;
+
+    let base_dir = if let Some(dir) = report_dir {
+        PathBuf::from(dir)
+    } else {
+        env::temp_dir()
+    };
+
+    let base_path = create_base_path(base_dir, hostname.trim(), "collect")
+        .map_err(|e| anyhow!("failed to create bundle base path: {e}"))?;
+
+    for group in groups {
+        println!(
+            "{} {} [{}] - {}",
+            style("Running Group").cyan(),
+            style(group.name()).cyan().bold(),
+            style(group.category()).white().bold(),
+            group.description()
+        );
+        let result = group.run().await;
+        result.log_individual_checks();
+        write_group_report(group, &result, &base_path)?;
+    }
+
+    create_gzip_from(base_path, host_executor).await
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod collect_cmd;
 mod postinstall_cmd;
 mod preinstall_cmd;
 
@@ -82,12 +83,25 @@ struct PostinstallArgs {
     report_dir: Option<String>,
 }
 
+#[derive(Args)]
+struct CollectArgs {
+    /// Directory path to write report to. Will be created if it doesn't exist. Defaults to `/tmp`
+    #[arg(short = 'd', long)]
+    report_dir: Option<String>,
+}
+
 #[derive(Subcommand)]
 enum Commands {
-    /// Run before installing Edera to validate hardware/host installation readiness.
+    #[command(
+        about = "Run before installing Edera to validate hardware/host installation readiness.\nAlso collects a system information snapshot."
+    )]
     Preinstall(PreinstallArgs),
-    /// Run after installing Edera to validate workload readiness.
+    #[command(
+        about = "Run after installing Edera to validate workload readiness.\nAlso collects a system information snapshot."
+    )]
     Postinstall(PostinstallArgs),
+    #[command(about = "Run after installing Edera to collect a system information snapshot.")]
+    Collect(CollectArgs),
 }
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 10)]
@@ -120,6 +134,7 @@ async fn main() -> Result<()> {
             )
             .await
         }
+        Commands::Collect(args) => collect_cmd::do_collect(args.report_dir).await,
     }
 }
 


### PR DESCRIPTION
Adds `edera-check collect` subcommand which skips `postinstall` checks and _only_ gathers the system report bundle, which we already collect as a side effect of the `postinstall` check.