### PR TITLE
Add KVM based checks 

### DIFF
--- a/src/checkers/preinstall/kernel.rs
+++ b/src/checkers/preinstall/kernel.rs
@@ -65,34 +65,7 @@ impl KernelChecks {
         let required_modules: Vec<String> =
             REQUIRED_MODULES.iter().map(|s| s.to_string()).collect();
 
-        // Search builtin modules
-        let remaining = match khelper::find_builtins(&self.host_executor, &required_modules).await {
-            Ok(r) => r,
-            Err(e) => {
-                return CheckResult::new(&name, Errored(format!("getting kernel builtins {e}")));
-            }
-        };
-
-        // Search loaded modules
-        let remaining = match khelper::find_loaded(&self.host_executor, &remaining).await {
-            Ok(r) => r,
-            Err(e) => {
-                return CheckResult::new(&name, Errored(format!("getting kernel modules {e}")));
-            }
-        };
-
-        // Search loadable modules (present in modules.dep but not yet loaded)
-        let remaining = match khelper::find_loadable(&self.host_executor, &remaining).await {
-            Ok(r) => r,
-            Err(e) => {
-                return CheckResult::new(&name, Errored(format!("getting kernel modules {e}")));
-            }
-        };
-        if !remaining.is_empty() {
-            return CheckResult::new(&name, Failed(format!("missing {:?}", remaining)));
-        }
-
-        CheckResult::new(&name, Passed)
+        khelper::check_modules(name, &self.host_executor, &required_modules).await
     }
 }
 

--- a/src/checkers/preinstall/kvm.rs
+++ b/src/checkers/preinstall/kvm.rs
@@ -1,0 +1,153 @@
+use log::debug;
+use std::fs;
+use std::path::Path;
+use std::result::Result::Ok;
+
+use crate::helpers::{
+    CheckGroup, CheckGroupResult, CheckResult,
+    CheckResultValue::{Errored, Failed, Passed},
+    cpu,
+    host_executor::HostNamespaceExecutor,
+};
+use crate::helpers::{CheckGroupCategory, kernel};
+use futures::{FutureExt, future::join_all};
+
+use async_trait::async_trait;
+
+const GROUP_IDENTIFIER: &str = "kvm";
+const NAME: &str = "KVM checks";
+
+pub struct KvmChecks {
+    host_executor: HostNamespaceExecutor,
+}
+
+impl KvmChecks {
+    pub fn new(host_executor: HostNamespaceExecutor) -> Self {
+        KvmChecks { host_executor }
+    }
+
+    async fn check_dev_kvm(&self) -> CheckResult {
+        let name = String::from("/dev/kvm check");
+
+        match self
+            .host_executor
+            .spawn_in_host_ns(async {
+                if Path::new("/dev/kvm").exists() {
+                    return true;
+                }
+                false
+            })
+            .await
+        {
+            Ok(true) => CheckResult::new(&name, Passed),
+            Ok(false) => CheckResult::new(
+                &name,
+                Failed("/dev/kvm doesn't exist on the host".to_string()),
+            ),
+            Err(e) => {
+                debug!("Error: {}", e);
+                CheckResult::new(&name, Errored(e.to_string()))
+            }
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    async fn has_modules(&self) -> CheckResult {
+        let name = String::from("Host has necessary kernel modules");
+        let required_modules: Vec<String> = vec!["vhost_vsock".to_string()];
+
+        kernel::check_modules(name, &self.host_executor, &required_modules).await
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    async fn has_modules(&self) -> CheckResult {
+        let name = String::from("Host has necessary kernel modules");
+        let mut required_modules: Vec<String> = vec!["vhost_vsock".to_string()];
+
+        // get the cpu vendor because based on who it is we will be checking for a different
+        // kvm module
+        let cpuinfo_res = match self
+            .host_executor
+            .spawn_in_host_ns(async { fs::read_to_string("/proc/cpuinfo") })
+            .await
+        {
+            Ok(info) => info,
+            Err(e) => {
+                return CheckResult::new(&name, Errored(e.to_string()));
+            }
+        };
+
+        // We need to match twice so we clarify whether the error was a JoinError
+        // or an error from fs::read_to_string
+        let cpuinfo = match cpuinfo_res {
+            Ok(info) => info,
+            Err(e) => {
+                return CheckResult::new(&name, Errored(e.to_string()));
+            }
+        };
+
+        let cpu_vendor = cpu::extract_cpu_vendor(&cpuinfo);
+
+        match cpu_vendor.as_str() {
+            "GenuineIntel" => {
+                required_modules.push("kvm_intel".to_string());
+            }
+            "AuthenticAMD" => {
+                required_modules.push("kvm_amd".to_string());
+            }
+            _ => {
+                return CheckResult::new(
+                    &name,
+                    Errored(format!("Unknown CPU vendor: {cpu_vendor}")),
+                );
+            }
+        }
+
+        kernel::check_modules(name, &self.host_executor, &required_modules).await
+    }
+
+    pub async fn run_all(&self) -> CheckGroupResult {
+        let results = join_all([self.has_modules().boxed(), self.check_dev_kvm().boxed()]).await;
+
+        let mut group_result = Passed;
+        for res in results.iter() {
+            // Set group result to Failed if we failed and aren't already in an Errored state
+            if !matches!(group_result, Errored(_)) && matches!(res.result, Failed(_)) {
+                group_result = Failed("".into());
+            }
+
+            if matches!(res.result, Errored(_)) {
+                group_result = Errored("".into());
+            }
+        }
+
+        CheckGroupResult {
+            name: NAME.to_string(),
+            result: group_result,
+            results,
+        }
+    }
+}
+
+#[async_trait]
+impl CheckGroup for KvmChecks {
+    fn id(&self) -> &str {
+        GROUP_IDENTIFIER
+    }
+
+    fn name(&self) -> &str {
+        NAME
+    }
+
+    fn description(&self) -> &str {
+        "KVM availability checks"
+    }
+
+    async fn run(&self) -> CheckGroupResult {
+        self.run_all().await
+    }
+
+    fn category(&self) -> CheckGroupCategory {
+        CheckGroupCategory::Required
+    }
+}

--- a/src/checkers/preinstall/kvm.rs
+++ b/src/checkers/preinstall/kvm.rs
@@ -1,5 +1,4 @@
 use log::debug;
-use std::fs;
 use std::path::Path;
 use std::result::Result::Ok;
 
@@ -64,28 +63,15 @@ impl KvmChecks {
         let name = String::from("Host has necessary kernel modules");
         let mut required_modules: Vec<String> = vec!["vhost_vsock".to_string()];
 
+        let cpuinfo = match cpu::read_cpuinfo(&self.host_executor).await {
+            Ok(info) => info,
+            Err(e) => {
+                return CheckResult::new(&name, Errored(e.to_string()));
+            }
+        };
+
         // get the cpu vendor because based on who it is we will be checking for a different
         // kvm module
-        let cpuinfo_res = match self
-            .host_executor
-            .spawn_in_host_ns(async { fs::read_to_string("/proc/cpuinfo") })
-            .await
-        {
-            Ok(info) => info,
-            Err(e) => {
-                return CheckResult::new(&name, Errored(e.to_string()));
-            }
-        };
-
-        // We need to match twice so we clarify whether the error was a JoinError
-        // or an error from fs::read_to_string
-        let cpuinfo = match cpuinfo_res {
-            Ok(info) => info,
-            Err(e) => {
-                return CheckResult::new(&name, Errored(e.to_string()));
-            }
-        };
-
         let cpu_vendor = cpu::extract_cpu_vendor(&cpuinfo);
 
         match cpu_vendor.as_str() {

--- a/src/checkers/preinstall/mod.rs
+++ b/src/checkers/preinstall/mod.rs
@@ -1,6 +1,7 @@
 pub mod byo_kernel;
 pub mod iommu;
 pub mod kernel;
+pub mod kvm;
 pub mod numa;
 pub mod pvh;
 pub mod system;

--- a/src/checkers/preinstall/pvh.rs
+++ b/src/checkers/preinstall/pvh.rs
@@ -1,7 +1,7 @@
 use crate::helpers::{
     CheckGroup, CheckGroupCategory, CheckGroupResult, CheckResult,
     CheckResultValue::{Errored, Failed, Passed},
-    cpu::{extract_cpu_vendor, extract_flags},
+    cpu::{extract_cpu_vendor, extract_flags, read_cpuinfo},
     host_executor::HostNamespaceExecutor,
 };
 use anyhow::{Result, bail};
@@ -9,7 +9,6 @@ use async_trait::async_trait;
 use futures::{FutureExt, future::join_all};
 use log::{debug, error, warn};
 use std::{
-    fs,
     fs::File,
     io::{Read, Seek, SeekFrom},
     path::Path,
@@ -112,11 +111,7 @@ impl PVHChecks {
     }
 
     async fn discover_cpu_virtualization(&self) -> Result<VirtStatus> {
-        let cpuinfo = self
-            .host_executor
-            .spawn_in_host_ns(async { fs::read_to_string("/proc/cpuinfo") })
-            .await??;
-
+        let cpuinfo = read_cpuinfo(&self.host_executor).await?;
         let cpu_vendor = extract_cpu_vendor(&cpuinfo);
         let flags = extract_flags(&cpuinfo);
 

--- a/src/checkers/preinstall/pvh.rs
+++ b/src/checkers/preinstall/pvh.rs
@@ -1,6 +1,7 @@
 use crate::helpers::{
     CheckGroup, CheckGroupCategory, CheckGroupResult, CheckResult,
     CheckResultValue::{Errored, Failed, Passed},
+    cpu::{extract_cpu_vendor, extract_flags},
     host_executor::HostNamespaceExecutor,
 };
 use anyhow::{Result, bail};
@@ -306,26 +307,4 @@ impl CheckGroup for PVHChecks {
     fn category(&self) -> CheckGroupCategory {
         CheckGroupCategory::Optional("PVH feature may not be available on this system".into())
     }
-}
-
-fn extract_cpu_vendor(cpuinfo: &str) -> String {
-    for line in cpuinfo.lines() {
-        if line.starts_with("vendor_id")
-            && let Some(value) = line.split(':').nth(1)
-        {
-            return value.trim().to_string();
-        }
-    }
-    String::from("Unknown")
-}
-
-fn extract_flags(cpuinfo: &str) -> String {
-    for line in cpuinfo.lines() {
-        if line.starts_with("flags")
-            && let Some(value) = line.split(':').nth(1)
-        {
-            return value.trim().to_string();
-        }
-    }
-    String::new()
 }

--- a/src/helpers/cpu.rs
+++ b/src/helpers/cpu.rs
@@ -1,3 +1,16 @@
+use std::fs;
+
+use anyhow::Result;
+
+use crate::helpers::host_executor::HostNamespaceExecutor;
+
+pub async fn read_cpuinfo(host_executor: &HostNamespaceExecutor) -> Result<String> {
+    let cpuinfo = host_executor
+        .spawn_in_host_ns(async { fs::read_to_string("/proc/cpuinfo") })
+        .await??;
+    Ok(cpuinfo)
+}
+
 pub fn extract_cpu_vendor(cpuinfo: &str) -> String {
     for line in cpuinfo.lines() {
         if line.starts_with("vendor_id")

--- a/src/helpers/cpu.rs
+++ b/src/helpers/cpu.rs
@@ -1,0 +1,21 @@
+pub fn extract_cpu_vendor(cpuinfo: &str) -> String {
+    for line in cpuinfo.lines() {
+        if line.starts_with("vendor_id")
+            && let Some(value) = line.split(':').nth(1)
+        {
+            return value.trim().to_string();
+        }
+    }
+    String::from("Unknown")
+}
+
+pub fn extract_flags(cpuinfo: &str) -> String {
+    for line in cpuinfo.lines() {
+        if line.starts_with("flags")
+            && let Some(value) = line.split(':').nth(1)
+        {
+            return value.trim().to_string();
+        }
+    }
+    String::new()
+}

--- a/src/helpers/kernel.rs
+++ b/src/helpers/kernel.rs
@@ -1,4 +1,8 @@
-use crate::helpers::host_executor::HostNamespaceExecutor;
+use crate::helpers::{
+    CheckResult,
+    CheckResultValue::{Errored, Failed, Passed},
+    host_executor::HostNamespaceExecutor,
+};
 
 use anyhow::{Result, bail};
 use log::debug;
@@ -121,4 +125,55 @@ pub async fn find_loadable(
         }
     }
     Ok(modules_to_find)
+}
+
+/// Try to check if a group of modules exist on a system through checking builtins,
+/// loaded, then loadable modules. This function is gonna be called by a check identified
+/// by parent_check_name
+pub async fn check_modules(
+    parent_check_name: String,
+    host_executor: &HostNamespaceExecutor,
+    required_modules: &[String],
+) -> CheckResult {
+    // Search builtin modules
+    let remaining = match find_builtins(host_executor, required_modules).await {
+        Ok(r) => r,
+        Err(e) => {
+            return CheckResult::new(
+                &parent_check_name,
+                Errored(format!("getting kernel builtins {e}")),
+            );
+        }
+    };
+
+    // Search loaded modules
+    let remaining = match find_loaded(host_executor, &remaining).await {
+        Ok(r) => r,
+        Err(e) => {
+            return CheckResult::new(
+                &parent_check_name,
+                Errored(format!("getting kernel modules {e}")),
+            );
+        }
+    };
+
+    // another namespace yet those checks should run in the host namespace
+    // Search loadable modules (present in modules.dep but not yet loaded)
+    let remaining = match find_loadable(host_executor, &remaining).await {
+        Ok(r) => r,
+        Err(e) => {
+            return CheckResult::new(
+                &parent_check_name,
+                Errored(format!("getting kernel modules {e}")),
+            );
+        }
+    };
+    if !remaining.is_empty() {
+        return CheckResult::new(
+            &parent_check_name,
+            Failed(format!("missing {:?}", remaining)),
+        );
+    }
+
+    CheckResult::new(&parent_check_name, Passed)
 }

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,3 +1,4 @@
+pub mod cpu;
 pub mod host_executor;
 pub mod kernel;
 pub mod services;

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,13 @@ enum PreinstallAction {
     ListChecks,
 }
 
+#[derive(Default, Clone, Debug, clap::ValueEnum)]
+enum BaseHypervisor {
+    #[default]
+    Xen,
+    Kvm,
+}
+
 #[derive(Subcommand)]
 enum PostinstallAction {
     /// List available check groups and their IDs.
@@ -52,6 +59,10 @@ struct PreinstallArgs {
     /// Collect information and configuration snapshot of current system (default true)
     #[arg(short, long, default_value_t = true)]
     record_hostinfo: bool,
+
+    /// Which hypervisor to run checks against
+    #[arg(long, default_value = "xen")]
+    hypervisor: BaseHypervisor,
 
     /// Run only selected checks, instead of default behavior of running all.
     /// Will override all other check enablement flags.
@@ -120,6 +131,7 @@ async fn main() -> Result<()> {
                 args.byo_kernel,
                 args.record_hostinfo,
                 args.only_checks,
+                args.hypervisor,
                 args.report_dir,
             )
             .await

--- a/src/preinstall_cmd.rs
+++ b/src/preinstall_cmd.rs
@@ -1,9 +1,11 @@
 use edera_check::checkers::preinstall::{
-    byo_kernel::BYOKernelChecks, iommu::IOMMUChecks, kernel::KernelChecks, numa::NUMAChecks,
-    pvh::PVHChecks, system::SystemChecks,
+    byo_kernel::BYOKernelChecks, iommu::IOMMUChecks, kernel::KernelChecks, kvm::KvmChecks,
+    numa::NUMAChecks, pvh::PVHChecks, system::SystemChecks,
 };
 
-use crate::{booted_under_edera, create_base_path, create_gzip_from, write_group_report};
+use crate::{
+    BaseHypervisor, booted_under_edera, create_base_path, create_gzip_from, write_group_report,
+};
 use anyhow::Result;
 use console::style;
 
@@ -23,6 +25,7 @@ pub async fn do_preinstall(
     byo_kernel: bool,
     record_hostinfo: bool,
     only_checks: Vec<String>,
+    run_checks_for: BaseHypervisor,
     report_dir: Option<String>,
 ) -> Result<()> {
     // If we are in a privileged container running in the host pid namespace,
@@ -32,13 +35,26 @@ pub async fn do_preinstall(
     // this is effectively a silent no-op.
     let host_executor = HostNamespaceExecutor::new();
 
-    let mut groups: Vec<Box<dyn CheckGroup>> = vec![
-        Box::new(SystemChecks::new(host_executor.clone())),
-        Box::new(PVHChecks::new(host_executor.clone())),
-        Box::new(KernelChecks::new(host_executor.clone())),
-        Box::new(IOMMUChecks::new(host_executor.clone())),
-        Box::new(NUMAChecks::new(host_executor.clone())),
-    ];
+    // a vector of boxed implementors of CheckGroup. a trait that represents a group of checks
+    // for a particular category of attributes
+    let mut groups: Vec<Box<dyn CheckGroup>> = match run_checks_for {
+        BaseHypervisor::Kvm => {
+            vec![
+                Box::new(PVHChecks::new(host_executor.clone())),
+                Box::new(KvmChecks::new(host_executor.clone())),
+                Box::new(IOMMUChecks::new(host_executor.clone())),
+            ]
+        }
+        BaseHypervisor::Xen => {
+            vec![
+                Box::new(SystemChecks::new(host_executor.clone())),
+                Box::new(PVHChecks::new(host_executor.clone())),
+                Box::new(KernelChecks::new(host_executor.clone())),
+                Box::new(IOMMUChecks::new(host_executor.clone())),
+                Box::new(NUMAChecks::new(host_executor.clone())),
+            ]
+        }
+    };
 
     if byo_kernel {
         groups.push(Box::new(BYOKernelChecks::new(host_executor.clone())));


### PR DESCRIPTION
Closes: https://github.com/edera-dev/edera-check/issues/154

## Explanation

Add a `hypervisor` flag to the preinstall command to specify that the kvm based group of checks should run (`/dev/kvm` exists, `kvm_amd` or `kvm_intel` exist, `vhost_vsock` exists)

Example successful run:
```
Running Group KVM checks [Optional] - Running edera in a KVM environment checks
    • Host contains the required modules for running edera on KVM: Passed
    • /dev/kvm check: Passed
✅ KVM checks: Passed
```

Example failed run:
```
Running Group KVM checks [Required] - Running edera in a KVM environment checks
    • Host contains the required modules for running edera on KVM: Failed: missing ["kvm_amd"]
    • /dev/kvm check: Failed: /dev/kvm doesn't exist on the host
❌ KVM checks: Failed
```
cc: @bleggett @antoineco 